### PR TITLE
feat: add drawer menu and skeleton settings/profile pages

### DIFF
--- a/lib/contact_list_page.dart
+++ b/lib/contact_list_page.dart
@@ -1,8 +1,12 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'add_contact_page.dart';
 import 'chat_page.dart';
 import 'contact.dart';
+import 'profile.dart';
+import 'settings.dart';
 import 'strings.dart';
 
 class ContactListItem extends StatelessWidget {
@@ -47,8 +51,8 @@ class _ContactListPageState extends State<ContactListPage> {
       drawer: Drawer(
         child: ListView(
           padding: EdgeInsets.zero,
-          children: const [
-            DrawerHeader(
+          children: <Widget>[
+            const DrawerHeader(
               decoration: BoxDecoration(
                 color: Colors.blue,
               ),
@@ -72,17 +76,41 @@ class _ContactListPageState extends State<ContactListPage> {
               ),
             ),
             ListTile(
-              leading: Icon(Icons.person),
-              title: Text('Profile'),
+              leading: const Icon(Icons.person),
+              title: const Text(Strings.menuProfile),
+              onTap: () {
+                Navigator.pop(context); // close drawer before navigating away
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const UserProfilePage(),
+                  ),
+                );
+              },
             ),
             ListTile(
-              leading: Icon(Icons.settings),
-              title: Text('Settings'),
+              leading: const Icon(Icons.settings),
+              title: const Text(Strings.menuSettings),
+              onTap: () {
+                Navigator.pop(context); // close drawer before navigating away
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const SettingsPage(),
+                  ),
+                );
+              },
             ),
-            ListTile(
-              leading: Icon(Icons.close),
-              title: Text('Quit'),
-            ),
+            defaultTargetPlatform == TargetPlatform.android
+                ? ListTile(
+                    leading: const Icon(Icons.close),
+                    title: const Text(Strings.menuQuit),
+                    onTap: () {
+                      SystemChannels.platform
+                          .invokeMethod('SystemNavigator.pop');
+                    },
+                  )
+                : const SizedBox.shrink(),
           ],
         ),
       ),

--- a/lib/contact_list_page.dart
+++ b/lib/contact_list_page.dart
@@ -44,7 +44,60 @@ class _ContactListPageState extends State<ContactListPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: const [
+            DrawerHeader(
+              decoration: BoxDecoration(
+                color: Colors.blue,
+              ),
+              child: ListTile(
+                title: Text(
+                  'YanciMan',
+                  style: TextStyle(
+                    fontSize: 16.0,
+                    color: Colors.white,
+                    fontWeight: FontWeight.w400,
+                  ),
+                ),
+                subtitle: Text(
+                  'Producing works of art in Kannywood',
+                  style: TextStyle(
+                    fontSize: 12.0,
+                    color: Colors.white,
+                    fontWeight: FontWeight.w100,
+                  ),
+                ),
+              ),
+            ),
+            ListTile(
+              leading: Icon(Icons.person),
+              title: Text('Profile'),
+            ),
+            ListTile(
+              leading: Icon(Icons.settings),
+              title: Text('Settings'),
+            ),
+            ListTile(
+              leading: Icon(Icons.close),
+              title: Text('Quit'),
+            ),
+          ],
+        ),
+      ),
       appBar: AppBar(
+        leading: Builder(
+          builder: (BuildContext context) {
+            return IconButton(
+              icon: const Icon(Icons.menu),
+              onPressed: () {
+                Scaffold.of(context).openDrawer();
+              },
+              tooltip: MaterialLocalizations.of(context).openAppDrawerTooltip,
+            );
+          },
+        ),
         title: Text(widget.title),
       ),
       body: ListView.builder(

--- a/lib/profile.dart
+++ b/lib/profile.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class UserProfilePage extends StatefulWidget {
+  final String title = 'Profile';
+
+  const UserProfilePage({Key? key}) : super(key: key);
+
+  @override
+  State<UserProfilePage> createState() => _UserProfilePageState();
+}
+
+class _UserProfilePageState extends State<UserProfilePage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: const Center(
+        child: Text('Username'),
+      ),
+    );
+  }
+}

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatefulWidget {
+  final String title = 'Settings';
+
+  const SettingsPage({Key? key}) : super(key: key);
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+    );
+  }
+}

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -15,4 +15,9 @@ class Strings {
   static const String add = 'Add';
   static const String toxIdLengthError = 'The Tox ID must be 76 characters';
   static const String messageEmptyError = "The message can't be empty";
+
+  // Drawer menu.
+  static const String menuProfile = 'Profile';
+  static const String menuQuit = 'Quit';
+  static const String menuSettings = 'Settings';
 }


### PR DESCRIPTION
The buttons don't actually do anything yet.

Edit: The settings buttons now navigate to skeleton pages and the quit button should now work, though it doesn't do anything on the chrome debugger.

Edit2: The profile page now lets you set your nick and status message. It's still very ugly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/btox/17)
<!-- Reviewable:end -->
