### PR TITLE
chore: Bump dependencies, update what we target in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,7 @@ jobs:
     - run: flutter build web
 
   windows-build:
-    # Flutter stable does not yet support VS 2022, so we use the windows-2019
-    # which comes with VS2019 pre-installed instead.
-    runs-on: windows-2019
+    runs-on: windows-2022
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
 
 env:
-  FLUTTER_VERSION: "2.10.0"
+  FLUTTER_VERSION: "2.10.1"
 
 jobs:
   format:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -182,14 +182,14 @@ packages:
       name: drift
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   fake_async:
     dependency: transitive
     description:
@@ -262,7 +262,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -283,7 +283,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: transitive
     description:
@@ -353,7 +353,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.9"
   path_provider_android:
     dependency: transitive
     description:
@@ -498,7 +498,7 @@ packages:
       name: sqlparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.19.2"
+    version: "0.20.0"
   stack_trace:
     dependency: transitive
     description:
@@ -582,7 +582,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.10"
+    version: "2.4.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -598,5 +598,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.15.1 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"
   flutter: ">=2.5.0"


### PR DESCRIPTION
See https://github.com/flutter/flutter/wiki/Hotfixes-to-the-Stable-Channel#2101-february-9-2022 for what's changed in Flutter 2.10.1. Sounds like the TextField bugs would affect even what we currently have implemented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/btox/23)
<!-- Reviewable:end -->
