### PR TITLE
fix: Fix add-contact page being unusable with smaller viewports

### DIFF
--- a/lib/add_contact_page.dart
+++ b/lib/add_contact_page.dart
@@ -32,61 +32,63 @@ class _AddContactPageState extends State<AddContactPage> {
       appBar: AppBar(
         title: const Text(Strings.addContact),
       ),
-      body: Form(
-        key: _formKey,
-        child: Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: TextFormField(
-                key: const Key('toxId'),
-                autovalidateMode: AutovalidateMode.onUserInteraction,
-                validator: (value) {
-                  value ??= '';
-                  if (value.length != 76) {
-                    return Strings.toxIdLengthError + ' (${value.length}/76)';
-                  }
-                  return null;
-                },
-                decoration: const InputDecoration(
-                  border: UnderlineInputBorder(),
-                  labelText: Strings.toxId,
-                ),
-                controller: _toxIdInputController,
-                textInputAction: TextInputAction.next,
-                autofocus: true,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: TextFormField(
-                autovalidateMode: AutovalidateMode.onUserInteraction,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return Strings.messageEmptyError;
-                  }
-                  return null;
-                },
-                decoration: const InputDecoration(
-                  border: UnderlineInputBorder(),
-                  labelText: Strings.message,
-                ),
-                onEditingComplete: () => _onAddContact(),
-                controller: _messageInputController,
-                textInputAction: TextInputAction.send,
-              ),
-            ),
-            Align(
-              alignment: Alignment.topRight,
-              child: Padding(
+      body: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              Padding(
                 padding: const EdgeInsets.all(16),
-                child: ElevatedButton(
-                  onPressed: _onAddContact,
-                  child: const Text(Strings.add),
+                child: TextFormField(
+                  key: const Key('toxId'),
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
+                  validator: (value) {
+                    value ??= '';
+                    if (value.length != 76) {
+                      return Strings.toxIdLengthError + ' (${value.length}/76)';
+                    }
+                    return null;
+                  },
+                  decoration: const InputDecoration(
+                    border: UnderlineInputBorder(),
+                    labelText: Strings.toxId,
+                  ),
+                  controller: _toxIdInputController,
+                  textInputAction: TextInputAction.next,
+                  autofocus: true,
                 ),
               ),
-            ),
-          ],
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: TextFormField(
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return Strings.messageEmptyError;
+                    }
+                    return null;
+                  },
+                  decoration: const InputDecoration(
+                    border: UnderlineInputBorder(),
+                    labelText: Strings.message,
+                  ),
+                  onEditingComplete: () => _onAddContact(),
+                  controller: _messageInputController,
+                  textInputAction: TextInputAction.send,
+                ),
+              ),
+              Align(
+                alignment: Alignment.topRight,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: ElevatedButton(
+                    onPressed: _onAddContact,
+                    child: const Text(Strings.add),
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
If you e.g. have the Android keyboard up (especially with the phone in
landscape mode), widgets lower on the page end up hidden behind the
keyboard.

This change makes it so that scrolling is allowed on the page, and so
e.g. hitting enter when you finish filling in a textfield will scroll to
the next one if it's out-of-view.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/btox/26)
<!-- Reviewable:end -->
