### PR TITLE
chore: Pin flutter in the Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  command = "if cd flutter; then git pull && cd ..; else git clone https://github.com/flutter/flutter.git; fi && export PATH=flutter/bin:$PATH && flutter config --enable-web && ./tools/prepare-web && flutter build web --release"
+  command = "if cd flutter; then git fetch && git reset --hard 3.10.6 && cd ..; else git clone https://github.com/flutter/flutter.git --branch 3.10.6; fi && export PATH=flutter/bin:$PATH && flutter config --enable-web && ./tools/prepare-web && flutter build web --release"


### PR DESCRIPTION
Before this, we were using the master branch of flutter here, leading to the preview not matching what you'd see when building bTox locally.

This was pretty obvious in the last PR where the master branch of flutter has fully migrated to the Material 3 theme whereas our version still has it as an opt-in.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/btox/35)
<!-- Reviewable:end -->
